### PR TITLE
Add rate limit for litellm

### DIFF
--- a/jobhunting-crew/AIAgents_Resume.ipynb
+++ b/jobhunting-crew/AIAgents_Resume.ipynb
@@ -186,6 +186,18 @@
    "source": [
     "import litellm\n",
     "from litellm import AnthropicChatCompletion"
+
+       # Add retry configuration here
+       litellm.num_retries = 3  # Number of retry attempts
+       litellm.request_timeout = 30  # Seconds
+
+     # Optional: Add exponential backoff settings
+     litellm.retry_config = {
+    "exponential_backoff": True,  # Use exponential backoff
+    "initial_delay": 1,  # Start with 1 second delay
+    "max_delay": 60,  # Maximum delay between retries (seconds)
+    "jitter": True  # Add randomness to prevent synchronized retries
+}
    ]
   },
   {


### PR DESCRIPTION
Configured retry mechanism to handle "Too many tokens" rate limit errors from AWS Bedrock.

Added num_retries=3 and exponential backoff to gracefully handle service limitations.